### PR TITLE
add inode to identify hard link group

### DIFF
--- a/metadata/.gitignore
+++ b/metadata/.gitignore
@@ -5,3 +5,4 @@ persistents.txt
 privatekey.pem
 regulars.txt
 symlinks.txt
+total_regular_size.txt

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -129,12 +129,15 @@ def gen_metadata(
         regular_list = []
         for d in regulars:
             size = os.path.getsize(os.path.join(target_dir, d))
+            stat = os.stat(os.path.join(target_dir, d))
+            nlink = stat.st_nlink
+            inode = stat.st_ino if nlink > 1 else ""
             regular_list.append(
                 f"{_join_mode_uid_gid(target_dir, d, nlink=True)},"
                 f"{_file_sha256(os.path.join(target_dir, d))},"
                 f"{_encapsulate(d, prefix=prefix)},"
-                f"{os.path.getsize(os.path.join(target_dir, d))},"
-                f"{os.stat(os.path.join(target_dir, d)).st_ino}"
+                f"{size},"
+                f"{inode}"
             )
             total_regular_size += size
         f.writelines("\n".join(regular_list))

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -122,8 +122,8 @@ def gen_metadata(
 
     # regulars.txt
     # format:
-    # mode,uid,gid,link number,sha256sum,'path/to/file'
-    # ex: 0644,1000,1000,1,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,'path/to/file',1234
+    # mode,uid,gid,link number,sha256sum,'path/to/file',size,inode
+    # ex: 0644,1000,1000,1,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,'path/to/file',1234,12345678
     total_regular_size = 0
     with open(os.path.join(output_dir, regular_file), "w") as f:
         regular_list = []
@@ -133,7 +133,8 @@ def gen_metadata(
                 f"{_join_mode_uid_gid(target_dir, d, nlink=True)},"
                 f"{_file_sha256(os.path.join(target_dir, d))},"
                 f"{_encapsulate(d, prefix=prefix)},"
-                f"{os.path.getsize(os.path.join(target_dir, d))}"
+                f"{os.path.getsize(os.path.join(target_dir, d))},"
+                f"{os.stat(os.path.join(target_dir, d)).st_ino}"
             )
             total_regular_size += size
         f.writelines("\n".join(regular_list))


### PR DESCRIPTION
# About this PR

In the current implementation, we can't identify which hard link files are the group.
e.g.
If there are 4 files - A, B, C, and D - and those files are the same hash and if the link number is 2, we can't identify which files are the group of a hard link. A and B, or A and C, or A and D, ...

# ticket
https://tier4.atlassian.net/browse/T4PB-17459

# test
confirmed ota client works with this inode information.