### PR TITLE
support compression

### DIFF
--- a/metadata/ota_metadata/metadata_sign.py
+++ b/metadata/ota_metadata/metadata_sign.py
@@ -48,6 +48,7 @@ def gen_payload(
     rootfs_directory,
     certificate_file,
     total_regular_size_file,
+    compressed_rootfs_directory,
 ):
     payload = [
         {"version": 1},
@@ -67,6 +68,8 @@ def gen_payload(
     if isfile(total_regular_size_file):
         total_regular_size = open(total_regular_size_file).read()
         payload.append({"total_regular_size": total_regular_size})
+    if compressed_rootfs_directory:
+        payload.append({"compressed_rootfs_directory": compressed_rootfs_directory})
     return urlsafe_b64encode(json.dumps(payload))
 
 
@@ -85,6 +88,7 @@ def sign_metadata(
     sign_key_file,
     cert_file,
     total_regular_size_file,
+    compressed_rootfs_directory,
     output_file,
 ):
     header = gen_header()
@@ -96,6 +100,7 @@ def sign_metadata(
         rootfs_directory,
         cert_file,
         total_regular_size_file,
+        compressed_rootfs_directory,
     )
     signature = sign(sign_key_file, f"{header}.{payload}")
     with open(output_file, "w") as f:
@@ -120,6 +125,9 @@ if __name__ == "__main__":
         "--rootfs-directory", help="rootfs directory.", default="rootfs"
     )
     parser.add_argument(
+        "--compressed-rootfs-directory", help="compressed rootfs directory.",
+    )
+    parser.add_argument(
         "--persistent-file", help="persistent file meta data.", required=True
     )
     parser.add_argument(
@@ -134,6 +142,7 @@ if __name__ == "__main__":
         regular_file=args.regular_file,
         persistent_file=args.persistent_file,
         rootfs_directory=args.rootfs_directory,
+        compressed_rootfs_directory=args.compressed_rootfs_directory,
         sign_key_file=args.sign_key,
         cert_file=args.cert_file,
         total_regular_size_file=args.total_regular_size_file,

--- a/metadata/ota_metadata/requirements.txt
+++ b/metadata/ota_metadata/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/tier4/igittigitt.git#egg=igittigitt
 cryptography==36.0.0
 tqdm==4.62.2
+pyzstd==0.15.3


### PR DESCRIPTION
# About this PR
This PR supports rootfs compression.
for metadata_gen.py:
if --compressed-dir is specified, The files under --target-dir are compressed under the directory specified by --compressed-dir.

for metadata_sign.py
if --compressed-rootfs-directory is specified, metadata.jwt contains `compressed_rootfs_directory` entry as follows:
```
[
  {
    "version": 1
  },
  {
    "directory": "dirs.txt",
    "hash": "7da1fe94d7a284d4e74080c27a681367347666b387b437d16350f4b8b811ccd7"
  },
  {
    "symboliclink": "symlinks.txt",
    "hash": "49232d6ea7f19c39dc0707922281fd2a3786f60362bd94842426990956816b0f"
  },
  {
    "regular": "regulars.txt",
    "hash": "89b49a5f12dea25885f4df60f71fd6ccf7fe499362daaf90f4576bcfc828b404"
  },
  {
    "persistent": "persistents.txt",
    "hash": "f816f282271403f3cc27f30898f78732e7f6ee1f3be667c69e12bdc2d1cc8d25"
  },
  {
    "rootfs_directory": "data"
  },
  {
    "certificate": "sign.pem",
    "hash": "7f1fd7b07e371dc2ff88085ff6aa59bfb929ae5fe390525475fa8c4d0518f25c"
  },
  {
    "total_regular_size": "5476789666"
  },
  {
    "compressed_rootfs_directory": "data.zst"
  }
]
```

If metadata.jwt contains `compressed_rootfs_directory`, OTA image is assumed to be compression supported.