### PR TITLE
Introduce optional zstd compression to metadata_gen

### DIFF
--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -36,17 +36,17 @@ def zstd_compress_file(
     cmpr_ratio: float,
     filesize_threshold: int,
 ) -> bool:
-    if (uncompressed_size := os.path.getsize(src_fpath)) < filesize_threshold:
+    if (src_size := os.path.getsize(src_fpath)) < filesize_threshold:
         return False  # skip file with too small size
     try:
         with open(src_fpath, "rb") as src_f, open(dst_fpath, "wb") as dst_f:
-            with cctx.stream_writer(dst_f) as compressor:
+            with cctx.stream_writer(dst_f, size=src_size) as compressor:
                 while data := src_f.read(CHUNK_SIZE):
                     compressor.write(data)
         # drop compressed file if cmpr ratio is too small or compressed failed
         if (
             not (compressed_bytes := os.path.getsize(dst_fpath))
-            or uncompressed_size / compressed_bytes < cmpr_ratio
+            or src_size / compressed_bytes < cmpr_ratio
         ):
             raise ValueError
         return True

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -36,18 +36,11 @@ def zstd_compress_file(
 ) -> bool:
     if (src_size := os.path.getsize(src_fpath)) < filesize_threshold:
         return False  # skip file with too small size
-
-    try:
-        with open(src_fpath, "rb") as src_f, open(dst_fpath, "wb") as dst_f:
-            with cctx.stream_writer(dst_f, size=src_size) as compressor:
-                while data := src_f.read(CHUNK_SIZE):
-                    compressor.write(data)
-    except Exception:  # cleanup on failure
-        try:
-            os.remove(dst_fpath)
-        except OSError:
-            pass
-        return False
+    # NOTE: interrupt the whole process if compression failed
+    with open(src_fpath, "rb") as src_f, open(dst_fpath, "wb") as dst_f:
+        with cctx.stream_writer(dst_f, size=src_size) as compressor:
+            while data := src_f.read(CHUNK_SIZE):
+                compressor.write(data)
     # drop compressed file if cmpr ratio is too small or compressed failed
     if (
         not (compressed_bytes := os.path.getsize(dst_fpath))

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -223,7 +223,9 @@ def gen_metadata(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument("--target-dir", help="target directory.", required=True)
     parser.add_argument(
         "--compressed-dir", help="the directory to save compressed file."

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2022 TIER IV, INC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,10 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-#!/usr/bin/env python3
-
 import os
 import argparse
 import pathlib
@@ -183,8 +181,8 @@ def gen_metadata(
 
     # regulars.txt
     # format:
-    # mode,uid,gid,link number,sha256sum,'path/to/file',size,inode[,compress_alg]
-    # ex: 0644,1000,1000,1,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,'path/to/file',1234,12345678[,zstd]
+    # mode,uid,gid,link number,sha256sum,'path/to/file',size,inode,[compress_alg]
+    # ex: 0644,1000,1000,1,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,'path/to/file',1234,12345678,[zstd]
     total_regular_size = 0
     with open(os.path.join(output_dir, regular_file), "w") as f:
         regular_list = []
@@ -232,13 +230,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compress-ratio",
         help="compression ratio threshold",
-        default=5,
+        default=1.25,  # uncompressed/compressed = 1.25
         type=float,
     )
     parser.add_argument(
         "--compress-filesize",
         help="lower bound size of file to be compressed",
-        default=512 * 1024,  # 512KiB
+        default=16 * 1024,  # 16KiB
         type=int,
     )
     parser.add_argument("--prefix", help="file name prefix.", default="/")

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -179,10 +179,18 @@ def gen_metadata(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("--target-dir", help="target directory.", required=True)
     parser.add_argument(
         "--compressed-dir", help="the directory to save compressed file."
+    )
+    parser.add_argument(
+        "--compress-ratio", help="compression ratio threshold", default=0.8
+    )
+    parser.add_argument(
+        "--compress-filesize",
+        help="lower bound size of file to be compressed",
+        default=512 * 1024,  # 512KiB
     )
     parser.add_argument("--prefix", help="file name prefix.", default="/")
     parser.add_argument("--output-dir", help="metadata output directory.", default=".")

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -49,7 +49,10 @@ def zstd_compress_file(
             raise ValueError
         return True
     except Exception:  # cleanup on failure
-        os.remove(dst_fpath)
+        try:
+            os.remove(dst_fpath)
+        except OSError:
+            pass
         return False
 
 

--- a/metadata/ota_metadata/metadata_sign.py
+++ b/metadata/ota_metadata/metadata_sign.py
@@ -48,6 +48,7 @@ def gen_payload(
     rootfs_directory,
     certificate_file,
     total_regular_size_file,
+    compressed_rootfs_directory,
 ):
     payload = [
         {"version": 1},
@@ -67,6 +68,8 @@ def gen_payload(
     if isfile(total_regular_size_file):
         total_regular_size = open(total_regular_size_file).read()
         payload.append({"total_regular_size": total_regular_size})
+    if compressed_rootfs_directory:
+        payload.append({"compressed_rootfs_directory": compressed_rootfs_directory})
     return urlsafe_b64encode(json.dumps(payload))
 
 
@@ -85,6 +88,7 @@ def sign_metadata(
     sign_key_file,
     cert_file,
     total_regular_size_file,
+    compressed_rootfs_directory,
     output_file,
 ):
     header = gen_header()
@@ -96,6 +100,7 @@ def sign_metadata(
         rootfs_directory,
         cert_file,
         total_regular_size_file,
+        compressed_rootfs_directory,
     )
     signature = sign(sign_key_file, f"{header}.{payload}")
     with open(output_file, "w") as f:
@@ -120,6 +125,9 @@ if __name__ == "__main__":
         "--rootfs-directory", help="rootfs directory.", default="rootfs"
     )
     parser.add_argument(
+        "--compressed-rootfs-directory", help="compressed rootfs directory.",
+    )
+    parser.add_argument(
         "--persistent-file", help="persistent file meta data.", required=True
     )
     parser.add_argument(
@@ -134,6 +142,7 @@ if __name__ == "__main__":
         regular_file=args.regular_file,
         persistent_file=args.persistent_file,
         rootfs_directory=args.rootfs_directory,
+        compressed_rootfs_directory=args.compressed_rootfs_directory,
         sign_key_file=args.sign_key,
         cert_file=args.cert_file,
         total_regular_size_file=args.total_regular_size_file,

--- a/metadata/ota_metadata/requirements.txt
+++ b/metadata/ota_metadata/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/tier4/igittigitt.git#egg=igittigitt
 cryptography==36.0.0
 tqdm==4.62.2
+pyzstd==0.15.3

--- a/metadata/ota_metadata/requirements.txt
+++ b/metadata/ota_metadata/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/tier4/igittigitt.git#egg=igittigitt
 cryptography==36.0.0
 tqdm==4.62.2
-pyzstd==0.15.3
+zstandard==0.18.0


### PR DESCRIPTION
## Introduction
This PR keeps the `metadata.jwt` format changes as PR #11 , and introduce `regulars.txt` format change to support optional file-based OTA image compression with zstd.

## Changes
Changes are only applied to `metadata_gen.py` comparing to PR #11.
1. metadata_gen: use zstandard package instead,
2. metadata_gen: compression threshold and compression filesize threshold are introduced to avoid unnecessary compression,
3. metadata_gen: introduce extra optional field <compress_alg> for regulars meta,
4. compressed file will have `zst` extension in the filename(`<sha256hash>.zst`).

## Ticket
[T4PB-20716](https://tier4.atlassian.net/browse/T4PB-20716)