### PR TITLE
fix: shebang and x-mode

### DIFF
--- a/metadata/ota_metadata/data_gen.py
+++ b/metadata/ota_metadata/data_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2022 TIER IV, INC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-#!/usr/bin/env python3
 
 import os
 import shutil

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#
+
 # Copyright 2022 TIER IV, INC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/metadata/ota_metadata/metadata_sign.py
+++ b/metadata/ota_metadata/metadata_sign.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2022 TIER IV, INC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,6 @@
 # limitations under the License.
 
 
-#!/usr/bin/env python3
 from os.path import basename, isfile
 from hashlib import sha256
 import base64
@@ -125,7 +126,8 @@ if __name__ == "__main__":
         "--rootfs-directory", help="rootfs directory.", default="rootfs"
     )
     parser.add_argument(
-        "--compressed-rootfs-directory", help="compressed rootfs directory.",
+        "--compressed-rootfs-directory",
+        help="compressed rootfs directory.",
     )
     parser.add_argument(
         "--persistent-file", help="persistent file meta data.", required=True


### PR DESCRIPTION
add x-mode (from 644 -> 755). CI/CD is assuming this mode.
fix shebang to the top.

https://github.com/tier4/ota-metadata/pull/9 seems to be removed x-mode.