### PR TITLE
fix: latest kernel for extlinux conf

### DIFF
--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -165,8 +165,11 @@ def _list_non_latest_kernels(boot_dir: Path):
 
     kfile_glob.remove(str(vmlinuz))
     ifile_glob.remove(str(initrd_img))
-    sfile_glob.remove(str(system_map))
-    cfile_glob.remove(str(config))
+    try:
+        sfile_glob.remove(str(system_map))  # system_map is optional
+        cfile_glob.remove(str(config))  # config is optional
+    except ValueError:
+        pass
     return kfile_glob + ifile_glob + sfile_glob + cfile_glob
 
 

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -136,6 +136,11 @@ def _get_latest_kernel_version(boot_dir: Path):
 
 
 def _list_non_latest_kernels(boot_dir: Path):
+    # if boot/extlinux/extlinux.conf exists, the kernel is specified in that file
+    # so we don't need to pickup the latest kernel.
+    if (boot_dir / "extlinux" / "extlinux.conf").is_file():
+        return []
+
     kfiles_path = str(boot_dir / "vmlinuz-*.*.*-*-*")
     ifiles_path = str(boot_dir / "initrd.img-*.*.*-*-*")
     sfiles_path = str(boot_dir / "System.map-*.*.*-*-*")

--- a/metadata/ota_metadata/tests/requirements.txt
+++ b/metadata/ota_metadata/tests/requirements.txt
@@ -1,0 +1,1 @@
+pytest-unordered==0.5.2

--- a/metadata/ota_metadata/tests/test_metadata_gen.py
+++ b/metadata/ota_metadata/tests/test_metadata_gen.py
@@ -1,0 +1,82 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import shutil
+import os
+from pathlib import Path
+from pytest_unordered import unordered
+
+
+def test_get_latest_kernel_version(tmp_path):
+    import metadata_gen
+
+    vmlinuzs = [
+        "vmlinuz-5.15.0-27-generic",
+        "vmlinuz-5.15.0-64-generic",
+        "vmlinuz-5.4.0-102-generic",
+        "vmlinuz-4.12.0-27-generic",
+    ]
+
+    for vmlinuz in vmlinuzs:
+        (tmp_path / vmlinuz).write_text("")
+    latest = metadata_gen._get_latest_kernel_version(tmp_path)
+    assert latest == tmp_path / "vmlinuz-5.15.0-64-generic"
+
+
+def test_list_non_latest_kernels(tmp_path):
+    import metadata_gen
+
+    vmlinuzs = [
+        "vmlinuz-5.15.0-27-generic",
+        "vmlinuz-5.15.0-64-generic",  # latest kernel
+        "vmlinuz-5.4.0-102-generic",
+        "vmlinuz-4.12.0-27-generic",
+    ]
+
+    initrd_imgs = [
+        "initrd.img-5.15.0-65-generic",
+        "initrd.img-5.15.0-64-generic",  # <- other than this should be returned
+        "initrd.img-5.4.0-102-generic",
+        "initrd.img-4.12.0-27-generic",
+    ]
+
+    for vmlinuz in vmlinuzs:
+        (tmp_path / vmlinuz).write_text("")
+
+    for initrd_img in initrd_imgs:
+        (tmp_path / initrd_img).write_text("")
+
+    latest = metadata_gen._list_non_latest_kernels(tmp_path)
+
+    assert latest == unordered(
+        [
+            str(tmp_path / "vmlinuz-5.15.0-27-generic"),
+            str(tmp_path / "vmlinuz-5.4.0-102-generic"),
+            str(tmp_path / "vmlinuz-4.12.0-27-generic"),
+            str(tmp_path / "initrd.img-5.15.0-65-generic"),
+            str(tmp_path / "initrd.img-5.4.0-102-generic"),
+            str(tmp_path / "initrd.img-4.12.0-27-generic"),
+        ]
+    )
+
+
+def test_list_non_latest_kernels_empty(tmp_path):
+    import metadata_gen
+
+    (tmp_path / "extlinux").mkdir()
+    (tmp_path / "extlinux" / "extlinux.conf").write_text("")
+
+    non_latests = metadata_gen._list_non_latest_kernels(tmp_path)
+    assert non_latests == []


### PR DESCRIPTION
In the rqx-58g platform, there is no vmlinuz-* files under boot directory.
When extlinux.conf exists, the kernel is specified by it, we don't need to unify the kernel file, since the kernel is explicitly specified by it.

rqx-58g boot directory:
```bash
$ ls
config                 initrd.img-4.9.201-rqx58g
config-4.9.201-rqx58g  initrd.sig
dtb                    kernel_tegra194-rqx-58g-tier4-isx021-gmsl2-camera-device-tree-overlay.dtb
extlinux               leopard-ar0233-gmsl-device-tree-overlay.dtbo
grub                   System.map
Image                  System.map-4.9.201-rqx58g
Image-4.9.201-rqx58g   tegra194-rqx-58g.dtb
Image.sig              tegra194-rqx-58g-hdr40.dtbo
initrd                 tier4-isx021-gmsl-device-tree-overlay.dtbo
```