### PR TITLE
feat(ota-metadata): improve ignore logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv
+__pycache__

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -200,7 +200,10 @@ def gen_metadata(
     #    2, If the file falls in some special folder pattern ?
     # Why we need to do this? It is explained in this document
     # https://tier4.atlassian.net/wiki/x/JoC21Q
-    check_patterns = [re.compile(r"home/autoware/[^/]+/build"), re.compile(r"home/autoware/[^/]+/src")]
+    check_patterns = [
+        re.compile(r"home/autoware/[^/]+/build"),
+        re.compile(r"home/autoware/[^/]+/src"),
+    ]
 
     # This is the flag to control if we will check and add files back to "build" and "src" folder
     check_symlink = any(
@@ -310,7 +313,7 @@ def gen_metadata(
                     path_to_check = os.path.join(path_to_check, path_name)
                     if os.path.islink(path_to_check):
                         additional_symlink_set.add(path_to_check)
-                        # if the target path is a symlink again, 
+                        # if the target path is a symlink again,
                         # we finish checking here.
                         break
                     elif os.path.isdir(path_to_check):

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -191,14 +191,14 @@ def gen_metadata(
     target_abs = Path(os.path.abspath(target_dir))
     ignore = ignore_rules(target_dir, ignore_file)
 
-    # If ignore file has the folders directories set:
+    # If ignore file has the following directories:
     #    1, "home/autoware/*/build"
     #    2, "home/autoware/*/src"
-    # We will NOT simply ignore files under this folders.
+    # We will NOT simply ignore files under them.
     # We will check the following:
     #    1, If the file is set as the target of a symblink ?
     #    2, If the file falls in some special folder pattern ?
-    # Why we need to do this? This is explained in this document
+    # Why we need to do this? It is explained in this document
     # https://tier4.atlassian.net/wiki/x/JoC21Q
     check_patterns = [r"home/autoware/[^/]+/build", r"home/autoware/[^/]+/src"]
 
@@ -209,7 +209,7 @@ def gen_metadata(
         for pattern in check_patterns
     )
 
-    # Special Pattern that we need to check add add files.
+    # Special Patterns that we need to check and add files.
     build_folder_patterns = [
         r"home/autoware/[^/]*/build/.*/hook/.*",
         r"home/autoware/[^/]*/build/.*/.*.egg-info/.*",
@@ -289,8 +289,8 @@ def gen_metadata(
         if check_symlink is False:
             continue
 
-        # Add the targeted file back to "regulars[]" and "dir[]"
-        # if they are under "home/autoware...../build" or "home/autoware...../src"
+        # Check the symlink target file
+        # if they are under "home/autoware/*/build" or "home/autoware/*/src"
 
         # when the target link is defined as "/link1/link2/link3"
         if symlink_target_path.startswith("/"):
@@ -306,7 +306,8 @@ def gen_metadata(
             # reformat the symlink target link to "/link1/link2/link3"
             symlink_target_path = os.path.relpath(target_path_abs, target_dir)
 
-        # In case the target link matches the ignore patten, we need to check and add it back to regulars[] and dirs[]
+        # In case the target link matches the ignore patten, 
+        # we need to check and add it back to regulars[] and dirs[]
         # Also, we need to the path level one by one.
         # In case the target link is a symlink, we will ignore it.
         if ignore.match(Path(target_path_abs)):
@@ -329,6 +330,9 @@ def gen_metadata(
     with open(os.path.join(output_dir, symlink_file), "w") as _f:
         _f.writelines("\n".join(symlink_list))
 
+    # Add additional files and directories here.
+    # Important to check check_symlink. 
+    # Make sure not affect the current behavior.
     if check_symlink:
         dirs.extend(additional_dir_set)
         regulars.extend(additional_regular_set)

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -232,9 +232,7 @@ def gen_metadata(
             if ignore.match(target_abs / str(f.relative_to(target_dir))):
                 if check_symlink:
                     relative_path = str(f.relative_to(target_dir))
-                    if any(
-                        re.search(pattern, relative_path) for pattern in check_patterns
-                    ):
+                    if any(pattern.search(relative_path) for pattern in check_patterns):
                         if f.is_symlink():
                             additional_symlink_set.add(relative_path)
                         elif f.is_dir():

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -228,26 +228,20 @@ def gen_metadata(
         try:
             if ignore.match(target_abs / str(f.relative_to(target_dir))):
                 if check_symlink:
+                    relative_path = str(f.relative_to(target_dir))
                     if any(
-                        bool(re.search(pattern, str(f.relative_to(target_dir))))
-                        for pattern in check_patterns
+                        re.search(pattern, relative_path) for pattern in check_patterns
                     ):
                         if f.is_dir() and not f.is_symlink():
-                            additional_dir_set.add(str(f.relative_to(target_dir)))
+                            additional_dir_set.add(relative_path)
                         elif f.is_symlink():
-                            additional_symlink_set.add(str(f.relative_to(target_dir)))
+                            additional_symlink_set.add(relative_path)
                         elif f.is_file() and not f.is_symlink():
                             if any(
-                                bool(
-                                    re.search(
-                                        file_pattern, str(f.relative_to(target_dir))
-                                    )
-                                )
+                                re.search(file_pattern, relative_path)
                                 for file_pattern in build_folder_patterns
                             ):
-                                additional_regular_set.add(
-                                    str(f.relative_to(target_dir))
-                                )
+                                additional_regular_set.add(relative_path)
                 continue
             if str(f) in non_latest_kernels:
                 print(f"INFO: {f} is not a latest kernel. skip.")

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -227,16 +227,16 @@ def gen_metadata(
     for f in p.glob("**/*"):
         try:
             if ignore.match(target_abs / str(f.relative_to(target_dir))):
-                if check_symlink is True:
+                if check_symlink:
                     if any(
                         bool(re.search(pattern, str(f.relative_to(target_dir))))
                         for pattern in check_patterns
                     ):
                         if f.is_dir() and not f.is_symlink():
                             additional_dir_set.add(str(f.relative_to(target_dir)))
-                        if f.is_symlink():
+                        elif f.is_symlink():
                             additional_symlink_set.add(str(f.relative_to(target_dir)))
-                        if f.is_file() and not f.is_symlink():
+                        elif f.is_file() and not f.is_symlink():
                             if any(
                                 bool(
                                     re.search(

--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -306,7 +306,7 @@ def gen_metadata(
             # reformat the symlink target link to "/link1/link2/link3"
             symlink_target_path = os.path.relpath(target_path_abs, target_dir)
 
-        # In case the target link matches the ignore patten, 
+        # In case the target link matches the ignore patten,
         # we need to check and add it back to regulars[] and dirs[]
         # Also, we need to the path level one by one.
         # In case the target link is a symlink, we will ignore it.
@@ -331,7 +331,7 @@ def gen_metadata(
         _f.writelines("\n".join(symlink_list))
 
     # Add additional files and directories here.
-    # Important to check check_symlink. 
+    # Important to check check_symlink.
     # Make sure not affect the current behavior.
     if check_symlink:
         dirs.extend(additional_dir_set)

--- a/metadata/ota_metadata/tests/README.md
+++ b/metadata/ota_metadata/tests/README.md
@@ -1,0 +1,10 @@
+# How to run the test
+
+Under the root folder, run the following commands
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r metadata/ota_metadata/requirements.txt
+pip3 install -r metadata/ota_metadata/tests/requirements.txt
+pytest metadata/ota_metadata/tests/test_metadata_gen.py

--- a/metadata/ota_metadata/tests/README.md
+++ b/metadata/ota_metadata/tests/README.md
@@ -7,4 +7,4 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip3 install -r metadata/ota_metadata/requirements.txt
 pip3 install -r metadata/ota_metadata/tests/requirements.txt
-pytest metadata/ota_metadata/tests/test_metadata_gen.py
+pytest metadata/ota_metadata/tests/

--- a/metadata/ota_metadata/tests/requirements.txt
+++ b/metadata/ota_metadata/tests/requirements.txt
@@ -1,4 +1,6 @@
 black==22.3.0
 flake8==4.0.1
+pytest==6.2.5
 pytest-cov==3.0.0
 pytest-unordered==0.5.2
+

--- a/metadata/ota_metadata/tests/test_metadata_gen.py
+++ b/metadata/ota_metadata/tests/test_metadata_gen.py
@@ -76,3 +76,113 @@ def test_list_non_latest_kernels_empty(tmp_path):
 
     non_latests = metadata_gen._list_non_latest_kernels(tmp_path)
     assert non_latests == []
+
+
+def test_gen_metadata_method(tmp_path):
+    import metadata_gen
+    import os
+
+    vmlinuzs = [
+        "vmlinuz-5.15.0-27-generic",
+        "vmlinuz-5.15.0-64-generic",  # latest kernel
+        "vmlinuz-5.4.0-102-generic",
+        "vmlinuz-4.12.0-27-generic",
+    ]
+
+    initrd_imgs = [
+        "initrd.img-5.15.0-65-generic",
+        "initrd.img-5.15.0-64-generic",  # <- other than this should be returned
+        "initrd.img-5.4.0-102-generic",
+        "initrd.img-4.12.0-27-generic",
+    ]
+
+    (tmp_path / "boot").mkdir()
+    for vmlinz in vmlinuzs:
+        (tmp_path / "boot" / vmlinz).mkdir()
+    for img in initrd_imgs:
+        (tmp_path / "boot" / img).mkdir()
+
+    compress_folder = str(tmp_path) + "/data.zst"
+    output_folder = str(tmp_path)
+
+    symlink_file = "symlink.txt"
+    dir_file = "dirs.txt"
+    regular_file = "regulars.txt"
+
+    ignore_patterns = [
+        "home/autoware/autoware.proj/build",
+        "home/autoware/autoware.proj/src",
+    ]
+    dummy_ignore_file = tmp_path / "ignore_file.txt"
+    dummy_ignore_file.write_text("\n".join(ignore_patterns))
+
+    (tmp_path / "home").mkdir()
+    (tmp_path / "home" / "autoware").mkdir()
+    (tmp_path / "home" / "autoware" / "autoware.proj").mkdir()
+
+    build_folder = "home/autoware/autoware.proj/build"
+    src_folder = "home/autoware/autoware.proj/src"
+    install_folder = "home/autoware/autoware.proj/install"
+
+    (tmp_path / build_folder).mkdir()
+    (tmp_path / src_folder).mkdir()
+    (tmp_path / install_folder).mkdir()
+
+    build_file1 = tmp_path / build_folder / "file_001"
+    build_file1.write_text("")
+    build_file2 = tmp_path / build_folder / "file_002"
+    build_file2.write_text("")
+
+    src_file1 = tmp_path / src_folder / "file_001"
+    src_file1.write_text("")
+    src_file2 = tmp_path / src_folder / "file_002"
+    src_file2.write_text("")
+
+    install_file1 = tmp_path / install_folder / "file_001"
+    install_file2 = tmp_path / install_folder / "file_002"
+    install_file3 = tmp_path / install_folder / "file_003"
+
+    os.symlink("/" + str(os.path.relpath(build_file1, tmp_path)), str(install_file1))
+    os.symlink(str(os.path.relpath(build_file2, install_folder)), str(install_file2))
+    os.symlink(str(os.path.relpath(src_file1, install_folder)), str(install_file3))
+
+    metadata_gen.gen_metadata(
+        target_dir=str(tmp_path),
+        compressed_dir=compress_folder,
+        prefix="/",
+        output_dir=output_folder,
+        directory_file=dir_file,
+        symlink_file=symlink_file,
+        regular_file=regular_file,
+        total_regular_size_file="total_regular_size_.txt",
+        ignore_file=str(tmp_path) + "/ignore_file.txt",
+        cmpr_ratio=1.25,
+        filesize_threshold=16 * 1024,
+    )
+
+    assert (
+        str(os.path.relpath(install_file1, tmp_path))
+        in (tmp_path / output_folder / symlink_file).read_text()
+    )
+    assert (
+        str(os.path.relpath(install_file2, tmp_path))
+        in (tmp_path / output_folder / symlink_file).read_text()
+    )
+
+    assert (
+        str(os.path.relpath(build_file1, tmp_path))
+        in (tmp_path / output_folder / regular_file).read_text()
+    )
+    assert (
+        str(os.path.relpath(build_file2, tmp_path))
+        in (tmp_path / output_folder / regular_file).read_text()
+    )
+
+    assert (
+        str(os.path.relpath(src_file1, tmp_path))
+        in (tmp_path / output_folder / regular_file).read_text()
+    )
+    assert (
+        not str(os.path.relpath(src_file2, tmp_path))
+        in (tmp_path / output_folder / regular_file).read_text()
+    )


### PR DESCRIPTION
### Purpose of this change:

Related JIRA : [RT4-14655](https://tier4.atlassian.net/browse/RT4-14655)
Related document: https://tier4.atlassian.net/wiki/x/JoC21Q

We want to remove files under the following folders:
"/home/autoware/....../build"
"/home/autoware/....../src"

But if when system build is using "colcon build --symlink-install", a lot of symlink files will be generated under "install" folder. 
The relation is like 
"/home/autoware/....../install"   -> "/home/autoware/....../build"
"/home/autoware/....../install"   -> "/home/autoware/....../src"
(And other mutual references also)

While there are so many files will not be necessary for runtime. 

This change will :
1, Keep the symlink-ed files under "build" and "src" folders.
2, Some other critical files under "build" folder will be kept also. 
3, This change will only function when ignore file contains 
            "/home/autoware/....../build"
            or
            "/home/autoware/....../src"
    definition.

### Verification we did

## Case 1: 
1) Define "/home/autoware/....../build" in ignore file
2) Generate OTA Images and Sign it
3) OTA update the generated images on VM
4) Try to launch "planning simulator" on VM

Tested OK for this case

## Case 2: 
1) Define "/home/autoware/....../build" and "/home/autoware/....../src" in ignore file
2) Generate OTA Images and Sign it
3) OTA update the generated images on VM
4) Try to launch "planning simulator" on VM

## Case 3: 
1) Remove definition of  "/home/autoware/....../build" in ignore file
2) Generate OTA Images and Sign it
3) Compared the "regulars.txt" , "symlink.txt", "dirs.txt" with original data (aks data generated before this change)
4) all the files should have completely the same files and folders. 

Tested OK for this case

[RT4-14655]: https://tier4.atlassian.net/browse/RT4-14655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Case 4: 
Tested the performance:
For the same set of files: 
Before the change: 139.3165 seconds
After the change: 193.5019 seconds
 -> extra time 54 seconds. 
This is acceptable extra time.