### PR TITLE
fix (ota-metadata) : Add "so" files under "build" folder always.

### DIFF
--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -216,6 +216,7 @@ def gen_metadata(
     build_folder_patterns = [
         re.compile(r"home/autoware/[^/]*/build/.*/hook/.*"),
         re.compile(r"home/autoware/[^/]*/build/.*/.*.egg-info/.*"),
+        re.compile(r"home/autoware/[^/]*/build/.*/.*.so$"),
     ]
 
     additional_symlink_set = set()


### PR DESCRIPTION
### About this PR
Related JIRA
https://tier4.atlassian.net/browse/RT4-16050

After this we deliver the following change
[RT4-15006](https://tier4.atlassian.net/browse/RT4-15006)

We received issue report that some “so“ files are missing from “build“ folder
([Slack Link](https://star4.slack.com/archives/C076ZGRC15X/p1744353163744689?thread_ts=1744177415.694539&cid=C076ZGRC15X))

Root cause of  this issue is that so of the "so" files are not symlinked to those unser "install" folder.
Since so files are important files, and change all autoware nodes to following the convention of creating symlink need time, we decided to keep all "so" files under "build" folder.

Test: 
Previously, the followng 6 so files are missing in different ECU's OTA Image (missing "so" files varies from each ECU)
After this change, we see all the missing "so" files are under build folder.

1) /autoware_tensorrt_yolox/libautoware_tensorrt_yolox_gpu_preprocess.so
2) /accelerated_image_processor/libcolor_space.so
3) /nebula_examples/libhesai_ros_offline_extract_pcd.so
4) /nebula_examples/libhesai_ros_offline_extract_bag_pcd.so
5) /nebula_examples/libvelodyne_ros_offline_extract_bag_pcd.so
6) /autoware_pose_estimator_arbiter/example_rule/libexample_rule.so


