### PR TITLE
ci: Add PR metrics workflow 

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -1,0 +1,42 @@
+name: Monthly issue metrics
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "3 2 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: issue metrics
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Get dates for last month
+        shell: bash
+        run: |
+          # Calculate the first day of the previous month
+          first_day=$(date -d "last month" +%Y-%m-01)
+
+          # Calculate the last day of the previous month
+          last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
+
+          #Set an environment variable with the date range
+          echo "$first_day..$last_day"
+          echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+
+      - name: Run issue-metrics tool
+        uses: github/issue-metrics@v3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEARCH_QUERY: 'repo:tier4/ota-metadata is:pr created:${{ env.last_month }} -reason:"not planned"'
+
+      - name: Create issue
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Monthly issue metrics report
+          token: ${{ secrets.GITHUB_TOKEN }}
+          content-filepath: ./issue_metrics.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   pytest_with_coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     strategy:
       matrix:
@@ -30,7 +30,7 @@ jobs:
           junitxml-path: ./pytest.xml
 
   python_lint_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     strategy:
       matrix:
@@ -54,7 +54,7 @@ jobs:
           $pythonLocation/bin/python -m flake8 metadata/ota_metadata
 
   markdown_lint_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - name: Checkout commit


### PR DESCRIPTION
### Why
To check PR metrics

### What
Add PR metrics workflow.
This workflow is based on [the official workflow](https://github.com/github/issue-metrics?tab=readme-ov-file#getting-started), and set the target as only PR(not Issue).