### PR TITLE
fix: forcefully add "/boot/ota" folder back (T4DEV-31869)

### DIFF
--- a/metadata/ota_metadata/metadata_gen.py
+++ b/metadata/ota_metadata/metadata_gen.py
@@ -269,13 +269,13 @@ def gen_metadata(
                             additional_symlink_set.add(relative_path)
                         elif f.is_dir():
                             additional_dir_set.add(relative_path)
-                        elif f.is_file() and any(
-                            _file_pattern.search(relative_path)
-                            for _file_pattern in pattern_to_keep
-                        ):
-                            additional_regular_set.add(relative_path)
                         else:
                             ignored_paths_to_delete_abs.add(Path(f).resolve())
+                    elif f.is_file() and any(
+                        _file_pattern.search(relative_path)
+                        for _file_pattern in pattern_to_keep
+                    ):
+                        additional_regular_set.add(relative_path)
                     else:
                         ignored_paths_to_delete_abs.add(Path(f).resolve())
                 continue


### PR DESCRIPTION
### About this PR

- "/boot/ota" folder is very important for OTA update. 
- But this folder is igored by default in CI/CD repo.
    (https://github.com/tier4/webauto-ci-buildspecs/blob/trunk/builder/ota/ignore_system.txt)

- When creating USB installer, CI/CD adds it back
   (https://github.com/tier4/webauto-ci-buildspecs/blob/trunk/lib/core/src/installer.ts)

- On the other hand. ota-metadata will remove all files that are not list in "regulars.txt"
- To avoid this issue, we forcefully add "/boot/ota" folder back to "regurlars.txt"