### PR TITLE
test: add zstandard API tests

### DIFF
--- a/metadata/ota_metadata/tests/test_metadata_gen.py
+++ b/metadata/ota_metadata/tests/test_metadata_gen.py
@@ -186,7 +186,8 @@ def test_gen_metadata_method(tmp_path):
         in (tmp_path / output_folder / regular_file).read_text()
     )
     assert (
-        str(os.path.relpath(src_file2, tmp_path)) not in (tmp_path / output_folder / regular_file).read_text()
+        str(os.path.relpath(src_file2, tmp_path))
+        not in (tmp_path / output_folder / regular_file).read_text()
     )
 
 

--- a/metadata/ota_metadata/tests/test_zstd_compression.py
+++ b/metadata/ota_metadata/tests/test_zstd_compression.py
@@ -31,10 +31,7 @@ CHUNK_SIZE = 4 * (1024**2)  # 4MiB
 @pytest.fixture
 def zstd_compressor():
     """Create a ZstdCompressor with production settings."""
-    return zstandard.ZstdCompressor(
-        level=COMPRESSION_LEVEL,
-        threads=MULTI_THREADS
-    )
+    return zstandard.ZstdCompressor(level=COMPRESSION_LEVEL, threads=MULTI_THREADS)
 
 
 @pytest.fixture
@@ -43,25 +40,29 @@ def zstd_decompressor():
     return zstandard.ZstdDecompressor()
 
 
-def test_zstd_stream_writer_with_size_hint(tmp_path, zstd_compressor, zstd_decompressor):
+def test_zstd_stream_writer_with_size_hint(
+    tmp_path, zstd_compressor, zstd_decompressor
+):
     """Test that stream_writer accepts size parameter correctly."""
     src_file = tmp_path / "test.txt"
     test_content = "Stream writer test " * 200
     src_file.write_text(test_content)
     src_size = src_file.stat().st_size
     dst_file = tmp_path / "test.zst"
-    
+
     with open(src_file, "rb") as src_f, open(dst_file, "wb") as dst_f:
         with zstd_compressor.stream_writer(dst_f, size=src_size) as compressor:
             compressor.write(src_f.read())
-    
+
     assert dst_file.exists()
     assert dst_file.stat().st_size > 0
-    
+
     decompressed_file = tmp_path / "decompressed.txt"
-    with open(dst_file, "rb") as compressed_f, open(decompressed_file, "wb") as decompressed_f:
+    with open(dst_file, "rb") as compressed_f, open(
+        decompressed_file, "wb"
+    ) as decompressed_f:
         zstd_decompressor.copy_stream(compressed_f, decompressed_f)
-    
+
     assert decompressed_file.read_text() == test_content
 
 
@@ -72,52 +73,58 @@ def test_zstd_stream_writer_chunk_writes(tmp_path, zstd_compressor, zstd_decompr
     src_file.write_text(test_content)
     src_size = src_file.stat().st_size
     dst_file = tmp_path / "large_test.zst"
-    
+
     write_count = 0
     with open(src_file, "rb") as src_f, open(dst_file, "wb") as dst_f:
         with zstd_compressor.stream_writer(dst_f, size=src_size) as compressor:
             while data := src_f.read(CHUNK_SIZE):
                 compressor.write(data)
                 write_count += 1
-    
+
     assert write_count >= 2
     assert dst_file.exists()
-    
+
     decompressed_file = tmp_path / "decompressed.txt"
-    with open(dst_file, "rb") as compressed_f, open(decompressed_file, "wb") as decompressed_f:
+    with open(dst_file, "rb") as compressed_f, open(
+        decompressed_file, "wb"
+    ) as decompressed_f:
         zstd_decompressor.copy_stream(compressed_f, decompressed_f)
-    
+
     assert decompressed_file.read_text() == test_content
 
 
-def test_zstd_stream_writer_without_size_hint(tmp_path, zstd_compressor, zstd_decompressor):
+def test_zstd_stream_writer_without_size_hint(
+    tmp_path, zstd_compressor, zstd_decompressor
+):
     """Test stream_writer without size parameter."""
     src_file = tmp_path / "test.txt"
     test_content = "Test without size hint " * 100
     src_file.write_text(test_content)
     dst_file = tmp_path / "test.zst"
-    
+
     with open(src_file, "rb") as src_f, open(dst_file, "wb") as dst_f:
         with zstd_compressor.stream_writer(dst_f) as compressor:
             compressor.write(src_f.read())
-    
+
     assert dst_file.exists()
-    
+
     decompressed_file = tmp_path / "decompressed.txt"
-    with open(dst_file, "rb") as compressed_f, open(decompressed_file, "wb") as decompressed_f:
+    with open(dst_file, "rb") as compressed_f, open(
+        decompressed_file, "wb"
+    ) as decompressed_f:
         zstd_decompressor.copy_stream(compressed_f, decompressed_f)
-    
+
     assert decompressed_file.read_text() == test_content
 
 
 def test_zstd_stream_writer_empty_data(tmp_path, zstd_compressor):
     """Test stream_writer with empty data."""
     dst_file = tmp_path / "empty.zst"
-    
+
     with open(dst_file, "wb") as dst_f:
         with zstd_compressor.stream_writer(dst_f) as compressor:
             compressor.write(b"")
-    
+
     assert dst_file.exists()
 
 
@@ -125,15 +132,17 @@ def test_zstd_stream_writer_binary_data(tmp_path, zstd_compressor, zstd_decompre
     """Test stream_writer with binary data."""
     binary_data = bytes([i % 256 for i in range(10000)])
     dst_file = tmp_path / "binary.zst"
-    
+
     with open(dst_file, "wb") as dst_f:
         with zstd_compressor.stream_writer(dst_f, size=len(binary_data)) as compressor:
             compressor.write(binary_data)
-    
+
     assert dst_file.exists()
-    
+
     decompressed_file = tmp_path / "binary_decompressed.bin"
-    with open(dst_file, "rb") as compressed_f, open(decompressed_file, "wb") as decompressed_f:
+    with open(dst_file, "rb") as compressed_f, open(
+        decompressed_file, "wb"
+    ) as decompressed_f:
         zstd_decompressor.copy_stream(compressed_f, decompressed_f)
-    
+
     assert decompressed_file.read_bytes() == binary_data


### PR DESCRIPTION
### Why
To ensure consistent behavior before and after upgrading the `zstandard` version.

### What
Add test cases for the `zstandard` APIs.
Currently, this repository only uses the `stream_writer` API, so the tests will focus on this API.