### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+This is the main entry for selecting a template for your PR.
+
+**Click** the `Preview` tab and **select** a PR template according to PR type:
+
+- [Feature](?expand=1&template=feature.md)
+- [Fix](?expand=1&template=fix.md)
+- [Refinement](?expand=1&template=refinement.md)
+
+If PR type is not in the above list, feel free to start from blank PR body.
+
+**DON'T INCLUDE THIS PAGE'S CONTENTS IN YOUR PR BODY.**

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,52 @@
+## Description
+
+<!-- Summarize the change this PR wants to introduce.
+
+For better understanding, adding reason/motivation of this PR are also recommended.
+
+-->
+
+## Check list
+
+<!-- A list of things needed to be done before set the PR as ready-for-review. -->
+
+- [ ] test file(s) that cover the change(s) are implemented.
+- [ ] local tests are passing.
+- [ ] design docs/implementation docs are prepared.
+
+## Documents
+
+<!-- For feature PR, design document is required. -->
+
+## Changes
+
+<!-- A list of code change(s) that introduced by this PR. -->
+
+## Behavior changes
+
+Does this PR introduce behavior change(s)?
+
+- [ ] Yes, internal behavior (will not impact user experience).
+- [ ] Yes, external behavior (will impact user experience).
+- [ ] No.
+
+### Previous behavior
+
+<!-- Behavior before the PR is introduced -->
+
+### Behavior with this PR
+
+<!-- Behavior after the PR is introduced -->
+
+## Breaking change
+
+Does this PR introduce breaking change(s)?
+
+- [ ] Yes.
+- [ ] No.
+
+<!-- List the breaking change(s) -->
+
+## Related links & tickets
+
+<!-- List of tickets or links related to this PR -->

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,0 +1,20 @@
+## Description
+
+<!-- Summarize the change this PR wants to introduce. -->
+
+## Check list
+
+<!-- A list of things needed to be done before set the PR as ready-for-review. -->
+
+- [ ] test files that cover the bug case(s) are implemented.
+- [ ] local tests are passing.
+
+## Bug fix
+
+### Current behavior
+
+### Behavior after fix
+
+## Related links & ticket
+
+<!-- List of tickets or links related to this PR -->

--- a/.github/PULL_REQUEST_TEMPLATE/refinement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refinement.md
@@ -1,0 +1,46 @@
+## Description
+
+<!-- Summarize the change this PR wants to introduce.
+
+For better understanding, adding reason/motivation of this PR are also recommended.
+-->
+
+## Check list
+
+<!-- A list of things needed to be done before set the PR as ready-for-review. -->
+
+- [ ] test file(s) that cover the change(s) are implemented.
+- [ ] local tests are passing.
+
+## Changes
+
+<!-- A list of code change(s) that introduced by this PR. -->
+
+## Behavior changes
+
+Does this PR introduce behavior change(s)?
+
+- [ ] Yes, internal behavior (will not impact user experience).
+- [ ] Yes, external behavior (will impact user experience).
+- [ ] No.
+
+### Previous behavior
+
+<!-- Behavior before the PR is introduced -->
+
+### Behavior with this PR
+
+<!-- Behavior after the PR is introduced -->
+
+## Breaking change
+
+Does this PR introduce breaking change(s)?
+
+- [ ] Yes.
+- [ ] No.
+
+<!-- List the breaking change(s) -->
+
+## Related links & tickets
+
+<!-- List of tickets or links related to this PR -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,44 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      # not include the PRs for updating pre-commit-ci hooks ver
+      - pre-commit-ci
+  categories:
+    - title: Security related!
+      labels:
+        - security
+    - title: Breaking Changes!
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Improvements & Refinements
+      labels:
+        - refactor
+        - refinement
+    - title: Build, CI & Dependencies
+      labels:
+        - build/ci
+        - dependencies
+    - title: Tests Updates
+      labels:
+        - test_files
+    - title: Docs Updates
+      labels:
+        - documentation
+    - title: Tools Updates
+      labels:
+        - tools
+    - title: Chore & Misc.
+      labels:
+        - chore
+        - misc
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
### Why
To use a standardized PR template across all repositories managed by the OTA team.

### What
Introduce a standardized PR template.